### PR TITLE
Fix build, add missing brace in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Then just type this in your `CMakeLists.txt`:
 add_subdirectory(i3ipc++)
 
 include_directories(${I3IPCpp_INCLUDE_DIRS})
-link_directories(${I3IPCpp_LIBRARY_DIRS)
+link_directories(${I3IPCpp_LIBRARY_DIRS})
 ...
 ```
 

--- a/src/ipc.cpp
+++ b/src/ipc.cpp
@@ -242,8 +242,8 @@ std::vector<output_t>  I3Connection::get_outputs() const {
 		outputs.push_back({
 			.name = name.asString(),
 			.active = active.asBool(),
-			.rect = parse_rect_from_json(rect),
 			.current_workspace = (current_workspace.isNull() ? std::string() : current_workspace.asString()),
+			.rect = parse_rect_from_json(rect),
 		});
 	}
 


### PR DESCRIPTION
Hi,

for me, building failed because two parts of the output_t struct were initialised in the wrong order. Swapping these two lines allowed building without further problems.

And as a second, there was a brace missing in the readme.

Best regards,
mox

p.S.> Are there any plans to make the sigc::signals carry the other information that is described in e.g. https://i3wm.org/docs/ipc.html#_workspaces_reply?
