### PR TITLE
Fix for W: Got a unknown "border" property: "pixel".

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,6 @@ project(i3ipc++)
 
 option(I3IPCpp_WITH_TESTS "Build unit tests executables" OFF)
 option(I3IPCpp_BUILD_EXAMPLES "Build example executables" OFF)
-option(I3IPCpp_USE_FULL_SIGNALS "Provide full JSON event object with the signals for workspace_event and window_event. !!CHANGES API!!" OFF)
 
 set(BUILD_STATIC_LIBS ON)
 set(BUILD_SHARED_LIBS OFF)
@@ -14,14 +13,7 @@ UNSET(BUILD_SHARED_LIBS)
 find_package(PkgConfig)
 pkg_check_modules(SIGCPP REQUIRED sigc++-2.0)
 
-# configure a header file to pass some settings to the source code
-configure_file (
-  "${PROJECT_SOURCE_DIR}/include/i3ipc++/i3ipc++_config.hpp.in"
-  "${PROJECT_BINARY_DIR}/include/i3ipc++_config.hpp"
-  )
-
 include_directories(
-	${PROJECT_BINARY_DIR}/include
 	${SIGCPP_INCLUDE_DIRS}
 	3rd/jsoncpp/include
 	3rd/auss/include
@@ -49,8 +41,7 @@ set(I3IPCpp_INCLUDE_DIRS
 set(I3IPCpp_LIBRARIES i3ipc++_static ${SIGCPP_LIBRARIES} jsoncpp_lib_static)
 
 set(I3IPCpp_LIBRARY_DIRS ${I3IPCpp_LIBRARY_DIRS} PARENT_SCOPE)
-set(I3IPCpp_INCLUDE_DIRS ${I3IPCpp_INCLUDE_DIRS})
-set(I3IPCpp_INCLUDE_DIRS ${I3IPCpp_INCLUDE_DIRS} ${PROJECT_BINARY_DIR}/include PARENT_SCOPE)
+set(I3IPCpp_INCLUDE_DIRS ${I3IPCpp_INCLUDE_DIRS} PARENT_SCOPE)
 set(I3IPCpp_LIBRARIES ${I3IPCpp_LIBRARIES} PARENT_SCOPE)
 
 if(I3IPCpp_BUILD_EXAMPLES)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ project(i3ipc++)
 
 option(I3IPCpp_WITH_TESTS "Build unit tests executables" OFF)
 option(I3IPCpp_BUILD_EXAMPLES "Build example executables" OFF)
+option(I3IPCpp_USE_FULL_SIGNALS "Provide full JSON event object with the signals for workspace_event and window_event. !!CHANGES API!!" OFF)
 
 set(BUILD_STATIC_LIBS ON)
 set(BUILD_SHARED_LIBS OFF)
@@ -13,7 +14,14 @@ UNSET(BUILD_SHARED_LIBS)
 find_package(PkgConfig)
 pkg_check_modules(SIGCPP REQUIRED sigc++-2.0)
 
+# configure a header file to pass some settings to the source code
+configure_file (
+  "${PROJECT_SOURCE_DIR}/include/i3ipc++/i3ipc++_config.hpp.in"
+  "${PROJECT_BINARY_DIR}/include/i3ipc++_config.hpp"
+  )
+
 include_directories(
+	${PROJECT_BINARY_DIR}/include
 	${SIGCPP_INCLUDE_DIRS}
 	3rd/jsoncpp/include
 	3rd/auss/include
@@ -40,7 +48,8 @@ set(I3IPCpp_INCLUDE_DIRS
 set(I3IPCpp_LIBRARIES i3ipc++_static ${SIGCPP_LIBRARIES} jsoncpp_lib_static)
 
 set(I3IPCpp_LIBRARY_DIRS ${I3IPCpp_LIBRARY_DIRS} PARENT_SCOPE)
-set(I3IPCpp_INCLUDE_DIRS ${I3IPCpp_INCLUDE_DIRS} PARENT_SCOPE)
+set(I3IPCpp_INCLUDE_DIRS ${I3IPCpp_INCLUDE_DIRS})
+set(I3IPCpp_INCLUDE_DIRS ${I3IPCpp_INCLUDE_DIRS} ${PROJECT_BINARY_DIR}/include PARENT_SCOPE)
 set(I3IPCpp_LIBRARIES ${I3IPCpp_LIBRARIES} PARENT_SCOPE)
 
 if(I3IPCpp_BUILD_EXAMPLES)

--- a/include/i3ipc++/ipc.hpp
+++ b/include/i3ipc++/ipc.hpp
@@ -5,6 +5,10 @@
 #include <memory>
 #include <vector>
 
+#ifdef USE_FULL_SIGNALS
+#include <json/json.h>
+#endif
+
 #include <sigc++/sigc++.h>
 
 extern "C" {
@@ -78,6 +82,7 @@ enum EventType {
 	ET_BARCONFIG_UPDATE = (1 << 4), /**< Bar config update event @attention Yet is not implemented as signal in I3Connection */
 };
 
+#ifndef USE_FULL_SIGNALS
 /**
  * Types of workspace events
  */
@@ -101,6 +106,7 @@ enum class WindowEventType : char {
 	FLOATING = '_', /**< Window toggled floating mode */
 	URGENT = 'u', /**< Window became urgent */
 };
+#endif
 
 struct buf_t;
 /**
@@ -169,11 +175,16 @@ public:
 	 */
 	void  handle_event();
 
-	sigc::signal<void, WorkspaceEventType>  signal_workspace_event; /**< Workspace event signal */
 	sigc::signal<void>  signal_output_event; /**< Output event signal */
 	sigc::signal<void>  signal_mode_event; /**< Output mode event signal */
-	sigc::signal<void, WindowEventType>  signal_window_event; /**< Window event signal */
 	sigc::signal<void>  signal_barconfig_update_event; /**< Barconfig update event signal */
+#ifdef USE_FULL_SIGNALS
+	sigc::signal<void, const Json::Value&>  signal_workspace_event; /**< Workspace event signal */
+	sigc::signal<void, const Json::Value&>  signal_window_event; /**< Window event signal */
+#else
+	sigc::signal<void, WorkspaceEventType>  signal_workspace_event; /**< Workspace event signal */
+	sigc::signal<void, WindowEventType>  signal_window_event; /**< Window event signal */
+#endif
 	sigc::signal<void, EventType, const std::shared_ptr<const buf_t>&>  signal_event; /**< i3 event signal @note Default handler routes event to signal according to type */
 private:
 	const int32_t  m_main_socket;

--- a/include/i3ipc++/ipc.hpp
+++ b/include/i3ipc++/ipc.hpp
@@ -5,7 +5,9 @@
 #include <memory>
 #include <vector>
 
-#ifdef USE_FULL_SIGNALS
+#include "i3ipc++_config.hpp"
+
+#ifdef I3IPCpp_USE_FULL_SIGNALS
 #include <json/json.h>
 #endif
 
@@ -82,7 +84,7 @@ enum EventType {
 	ET_BARCONFIG_UPDATE = (1 << 4), /**< Bar config update event @attention Yet is not implemented as signal in I3Connection */
 };
 
-#ifndef USE_FULL_SIGNALS
+#ifndef I3IPCpp_USE_FULL_SIGNALS
 /**
  * Types of workspace events
  */
@@ -178,7 +180,7 @@ public:
 	sigc::signal<void>  signal_output_event; /**< Output event signal */
 	sigc::signal<void>  signal_mode_event; /**< Output mode event signal */
 	sigc::signal<void>  signal_barconfig_update_event; /**< Barconfig update event signal */
-#ifdef USE_FULL_SIGNALS
+#ifdef I3IPCpp_USE_FULL_SIGNALS
 	sigc::signal<void, const Json::Value&>  signal_workspace_event; /**< Workspace event signal */
 	sigc::signal<void, const Json::Value&>  signal_window_event; /**< Window event signal */
 #else

--- a/include/i3ipc++/ipc.hpp
+++ b/include/i3ipc++/ipc.hpp
@@ -5,12 +5,6 @@
 #include <memory>
 #include <vector>
 
-#include "i3ipc++_config.hpp"
-
-#ifdef I3IPCpp_USE_FULL_SIGNALS
-#include <json/json.h>
-#endif
-
 #include <sigc++/sigc++.h>
 
 extern "C" {
@@ -85,7 +79,6 @@ enum EventType {
 	ET_BARCONFIG_UPDATE = (1 << 4), ///< Bar config update event @attention Yet is not implemented as signal in connection
 };
 
-#ifndef I3IPCpp_USE_FULL_SIGNALS
 /**
  * Types of workspace events
  */
@@ -118,6 +111,7 @@ enum class BorderStyle : char {
 	UNKNOWN = '?', //< If got an unknown border style in reply
 	NONE = 'N',
 	NORMAL = 'n',
+	PIXEL = 'P',
 	ONE_PIXEL = '1',
 };
 
@@ -159,7 +153,6 @@ struct container_t {
 
 	std::list< std::shared_ptr<container_t> >  nodes;
 };
-#endif
 
 
 /**

--- a/src/ipc.cpp
+++ b/src/ipc.cpp
@@ -4,9 +4,7 @@
 #include <iostream>
 
 #include <auss.hpp>
-#ifndef I3IPCpp_USE_FULL_SIGNALS
 #include <json/json.h>
-#endif
 
 #include "log.hpp"
 #include "ipc-util.hpp"
@@ -78,6 +76,8 @@ static std::shared_ptr<container_t>  parse_container_from_json(const Json::Value
 		container->border = BorderStyle::NORMAL;
 	} else if (border == "none") {
 		container->border = BorderStyle::NONE;
+	} else if (border == "pixel") {
+		container->border = BorderStyle::PIXEL;
 	} else if (border == "1pixel") {
 		container->border = BorderStyle::ONE_PIXEL;
 	} else {
@@ -177,6 +177,7 @@ std::string  get_socketpath() {
 	}
 	return str;
 }
+
 
 connection::connection(const std::string&  socket_path) : m_main_socket(i3_connect(socket_path)), m_event_socket(-1), m_subscriptions(0), m_socket_path(socket_path) {
 #define i3IPC_TYPE_STR "i3's event"

--- a/src/ipc.cpp
+++ b/src/ipc.cpp
@@ -4,7 +4,9 @@
 #include <iostream>
 
 #include <auss.hpp>
+#ifndef I3IPCpp_USE_FULL_SIGNALS
 #include <json/json.h>
+#endif
 
 #include "log.hpp"
 #include "ipc-util.hpp"
@@ -80,7 +82,7 @@ I3Connection::I3Connection(const std::string&  socket_path) : m_main_socket(i3_c
 		case ET_WORKSPACE: {
 			Json::Value  root;
 			IPC_JSON_READ(root);
-#ifdef USE_FULL_SIGNALS
+#ifdef I3IPCpp_USE_FULL_SIGNALS
 			signal_workspace_event.emit(root);
 #else
 			WorkspaceEventType  type;
@@ -114,7 +116,7 @@ I3Connection::I3Connection(const std::string&  socket_path) : m_main_socket(i3_c
 		case ET_WINDOW: {
 			Json::Value  root;
 			IPC_JSON_READ(root);
-#ifdef USE_FULL_SIGNALS
+#ifdef I3IPCpp_USE_FULL_SIGNALS
 			signal_window_event.emit(root);
 #else
 			WindowEventType  type;

--- a/src/ipc.cpp
+++ b/src/ipc.cpp
@@ -78,9 +78,12 @@ I3Connection::I3Connection(const std::string&  socket_path) : m_main_socket(i3_c
 	signal_event.connect([this](EventType  event_type, const std::shared_ptr<const buf_t>&  buf) {
 		switch (event_type) {
 		case ET_WORKSPACE: {
-			WorkspaceEventType  type;
 			Json::Value  root;
 			IPC_JSON_READ(root);
+#ifdef USE_FULL_SIGNALS
+			signal_workspace_event.emit(root);
+#else
+			WorkspaceEventType  type;
 			std::string  change = root["change"].asString();
 			if (change == "focus") {
 				type = WorkspaceEventType::FOCUS;
@@ -97,6 +100,7 @@ I3Connection::I3Connection(const std::string&  socket_path) : m_main_socket(i3_c
 			I3IPC_DEBUG("WORKSPACE " << change)
 
 			signal_workspace_event.emit(type);
+#endif
 			break;
 		}
 		case ET_OUTPUT:
@@ -108,9 +112,12 @@ I3Connection::I3Connection(const std::string&  socket_path) : m_main_socket(i3_c
 			signal_mode_event.emit();
 			break;
 		case ET_WINDOW: {
-			WindowEventType  type;
 			Json::Value  root;
 			IPC_JSON_READ(root);
+#ifdef USE_FULL_SIGNALS
+			signal_window_event.emit(root);
+#else
+			WindowEventType  type;
 			std::string  change = root["change"].asString();
 			if (change == "new") {
 				type = WindowEventType::NEW;
@@ -132,6 +139,7 @@ I3Connection::I3Connection(const std::string&  socket_path) : m_main_socket(i3_c
 			I3IPC_DEBUG("WINDOW " << change)
 
 			signal_window_event.emit(type);
+#endif
 			break;
 		}
 		case ET_BARCONFIG_UPDATE:


### PR DESCRIPTION
When setting "new window pixel 1" in the i3config, i3 will send "border" : "pixel" as border style in the tree reply.
Example:
{
    "border" : "pixel",
    "current_border_width" : -1,
    "deco_rect" : 
    {
        "height" : 0,
        "width" : 0,
        "x" : 0,
        "y" : 0
    },
    "floating" : "auto_off",
    "floating_nodes" : [],
    "focus" : [],
    "focused" : false,
    "fullscreen_mode" : 0,
    "geometry" : 
    {
        "height" : 0,
        "width" : 0,
        "x" : 0,
        "y" : 0
    },
    "id" : 31099360,
    "last_split_layout" : "splith",
    "layout" : "dockarea",
    "name" : "bottomdock",
    "nodes" : [],
    "orientation" : "none",
    "percent" : null,
    "rect" : 
    {
        "height" : 0,
        "width" : 1600,
        "x" : 0,
        "y" : 900
    },
    "scratchpad_state" : "none",
    "sticky" : false,
    "swallows" : 
    [
        {
            "dock" : 3,
            "insert_where" : 2
        }
    ],
    "type" : "dockarea",
    "urgent" : false,
    "window" : null,
    "window_rect" : 
    {
        "height" : 0,
        "width" : 0,
        "x" : 0,
        "y" : 0
    },
    "workspace_layout" : "default"
}
This pull request adds recognition for this border style.
On the other hand, I was not able to receive "1pixel" as border reply. I think the documentation of the IPC interface (interprocess communication) is just outdated there.
