### PR TITLE
[BUGFIX] Mistyped "current". 

### DIFF
--- a/src/ipc.cpp
+++ b/src/ipc.cpp
@@ -294,7 +294,7 @@ connection::connection(const std::string&  socket_path) : m_main_socket(i3_conne
 			I3IPC_DEBUG("WORKSPACE " << change)
 
 			Json::Value  current = root["current"];
-			Json::Value  old = root["current"];
+			Json::Value  old = root["old"];
 
 			if (!current.isNull()) {
 				ev.current = parse_workspace_from_json(current);


### PR DESCRIPTION
String "old" required for old workspace extraction.