### PR TITLE
Added support for undocumented WorkspaceEventTypes

### DIFF
--- a/include/i3ipc++/ipc.hpp
+++ b/include/i3ipc++/ipc.hpp
@@ -89,6 +89,9 @@ enum class WorkspaceEventType : char {
 	INIT = 'i', ///< Initialized
 	EMPTY = 'e', ///< Became empty
 	URGENT = 'u', ///< Became urgent
+    RENAME = 'r', ///< Renamed
+    RELOAD = 'l', ///< Reloaded
+    RESTORED = 's', ///< Restored
 };
 
 /**

--- a/include/i3ipc++/ipc.hpp
+++ b/include/i3ipc++/ipc.hpp
@@ -89,9 +89,9 @@ enum class WorkspaceEventType : char {
 	INIT = 'i', ///< Initialized
 	EMPTY = 'e', ///< Became empty
 	URGENT = 'u', ///< Became urgent
-    RENAME = 'r', ///< Renamed
-    RELOAD = 'l', ///< Reloaded
-    RESTORED = 's', ///< Restored
+	RENAME = 'r', ///< Renamed
+	RELOAD = 'l', ///< Reloaded
+	RESTORED = 's', ///< Restored
 };
 
 /**

--- a/src/ipc.cpp
+++ b/src/ipc.cpp
@@ -287,13 +287,13 @@ connection::connection(const std::string&  socket_path) : m_main_socket(i3_conne
 				ev.type = WorkspaceEventType::EMPTY;
 			} else if (change == "urgent") {
 				ev.type = WorkspaceEventType::URGENT;
-            } else if (change == "rename") {
-                ev.type = WorkspaceEventType::RENAME;
-            } else if (change == "reload") {
-                ev.type = WorkspaceEventType::RELOAD;
-            } else if (change == "restored") {
-                ev.type = WorkspaceEventType::RESTORED;
-            } else {
+			} else if (change == "rename") {
+				ev.type = WorkspaceEventType::RENAME;
+			} else if (change == "reload") {
+				ev.type = WorkspaceEventType::RELOAD;
+			} else if (change == "restored") {
+				ev.type = WorkspaceEventType::RESTORED;
+			} else {
 				I3IPC_WARN("Unknown workspace event type " << change)
 				break;
 			}

--- a/src/ipc.cpp
+++ b/src/ipc.cpp
@@ -287,7 +287,13 @@ connection::connection(const std::string&  socket_path) : m_main_socket(i3_conne
 				ev.type = WorkspaceEventType::EMPTY;
 			} else if (change == "urgent") {
 				ev.type = WorkspaceEventType::URGENT;
-			} else {
+            } else if (change == "rename") {
+                ev.type = WorkspaceEventType::RENAME;
+            } else if (change == "reload") {
+                ev.type = WorkspaceEventType::RELOAD;
+            } else if (change == "restored") {
+                ev.type = WorkspaceEventType::RESTORED;
+            } else {
 				I3IPC_WARN("Unknown workspace event type " << change)
 				break;
 			}


### PR DESCRIPTION
"reload", "restore" and "reload" are possible types of the workspace
event. They weren't documented (I will contact the responsible person).
I'm not sure if the "reload" signal can be received, but better be safe
than sorry.