### PR TITLE
Remove dynamic exception specifications

### DIFF
--- a/include/i3ipc++/ipc-util.hpp
+++ b/include/i3ipc++/ipc-util.hpp
@@ -144,7 +144,7 @@ void   i3_send(const int32_t  sockfd, const buf_t&  buff);
  * @param  sockfd  a socket
  * @return  a buffer of the message
  */
-std::shared_ptr<buf_t>   i3_recv(const int32_t  sockfd) throw (invalid_header_error, eof_error);
+std::shared_ptr<buf_t>   i3_recv(const int32_t  sockfd);
 
 /**
  * @brief Pack a buffer of message
@@ -160,7 +160,7 @@ std::shared_ptr<buf_t>  i3_pack(const ClientMessageType  type, const std::string
  * auto  reply = i3_recv(sockfd);
  * @endcode
  */
-std::shared_ptr<buf_t>  i3_msg(const int32_t  sockfd, const ClientMessageType  type, const std::string&  payload = std::string()) throw (invalid_header_error, eof_error);
+std::shared_ptr<buf_t>  i3_msg(const int32_t  sockfd, const ClientMessageType  type, const std::string&  payload = std::string());
 
 /**
  * @}

--- a/src/ipc-util.cpp
+++ b/src/ipc-util.cpp
@@ -115,7 +115,7 @@ void   i3_send(const int32_t  sockfd, const buf_t&  buff) {
 	swrite(sockfd, buff.data, buff.size);
 }
 
-std::shared_ptr<buf_t>   i3_recv(const int32_t  sockfd) throw (invalid_header_error, eof_error) {
+std::shared_ptr<buf_t>   i3_recv(const int32_t  sockfd) {
 	buf_t*  buff = new buf_t(0);
 	const uint32_t  header_size = sizeof(header_t);
 
@@ -159,7 +159,7 @@ std::shared_ptr<buf_t>   i3_recv(const int32_t  sockfd) throw (invalid_header_er
 }
 
 
-std::shared_ptr<buf_t>  i3_msg(const int32_t  sockfd, const ClientMessageType  type, const std::string&  payload) throw (invalid_header_error, eof_error) {
+std::shared_ptr<buf_t>  i3_msg(const int32_t  sockfd, const ClientMessageType  type, const std::string&  payload) {
 	auto  send_buff = i3_pack(type, payload);
 	i3_send(sockfd, *send_buff);
 	auto  recv_buff = i3_recv(sockfd);


### PR DESCRIPTION
They are deprecated since C++11 and removed in C++17.