### PR TITLE
Fixing member data type for rect_t to uin32_t

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,7 @@ target_link_libraries(i3ipc++
 )
 
 target_compile_options(i3ipc++
-	PUBLIC -std=c++11 -Wall -Wextra -Wno-unused-parameter
+	PRIVATE -std=c++11 -Wall -Wextra -Wno-unused-parameter
 )
 
 target_compile_definitions(i3ipc++

--- a/include/i3ipc++/ipc.hpp
+++ b/include/i3ipc++/ipc.hpp
@@ -28,10 +28,10 @@ std::string  get_socketpath();
  * Primitive of rectangle
  */
 struct rect_t {
-	int  x; ///< Position on X axis
-	int  y; ///< Position on Y axis
-	int  width; ///< Width of rectangle
-	int  height; ///< Height of rectangle
+	uint32_t  x; ///< Position on X axis
+	uint32_t  y; ///< Position on Y axis
+	uint32_t  width; ///< Width of rectangle
+	uint32_t  height; ///< Height of rectangle
 };
 
 /**

--- a/src/ipc.cpp
+++ b/src/ipc.cpp
@@ -42,10 +42,10 @@ std::vector<std::ostream*>  g_logging_err_outs = {
 
 inline rect_t  parse_rect_from_json(const Json::Value&  value) {
 	return {
-		.x = value["x"].asInt(),
-		.y = value["y"].asInt(),
-		.width = value["width"].asInt(),
-		.height = value["height"].asInt(),
+		.x = value["x"].asUInt(),
+		.y = value["y"].asUInt(),
+		.width = value["width"].asUInt(),
+		.height = value["height"].asUInt(),
 	};
 }
 


### PR DESCRIPTION
This PR makes https://github.com/drmgc/i3ipcpp/pull/16 obsolete. It is the same content, but started from scratch as I did not know how to atomize the PR. Sorry for the inconvenience.