### PR TITLE
Add workspace info and values map

### DIFF
--- a/examples/workspaces.cpp
+++ b/examples/workspaces.cpp
@@ -22,6 +22,9 @@ void  dump_tree_container(const i3ipc::container_t&  c, std::string&  prefix) {
 	std::cout << prefix << "current_border_width = " << c.current_border_width << std::endl;
 	std::cout << prefix << "layout = \"" << c.layout_raw << "\"" << std::endl;
 	std::cout << prefix << "percent = " << c.percent << std::endl;
+	if (c.workspace.has_value()) {
+		std::cout << prefix << "current_workspace = " << c.workspace.value() << std::endl;
+	}
 	if (c.urgent) {
 		std::cout << prefix << "urgent" << std::endl;
 	}

--- a/include/i3ipc++/ipc.hpp
+++ b/include/i3ipc++/ipc.hpp
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include <list>
+#include <optional>
 #include <string>
 #include <memory>
 #include <vector>
@@ -198,11 +199,14 @@ struct container_t {
 	rect_t  geometry; ///< The original geometry the window specified when i3 mapped it. Used when switching a window to floating mode, for example
 	bool  urgent;
 	bool  focused;
+	std::optional<std::string> workspace;
 
 	window_properties_t  window_properties; /// X11 window properties
 
 	std::list< std::shared_ptr<container_t> >  nodes;
 	std::list< std::shared_ptr<container_t> >  floating_nodes;
+
+	std::map<std::string, std::string> map;
 };
 
 


### PR DESCRIPTION
Depends on #30 for std::optional

- Add workspace to containers that are children of a workspace node
- Add a map containing the key->value pairs of json values
  - This adds support for `app_id` in sway as well as other values that may be added in future sway/i3 versions