### PR TITLE
Fix build issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,7 @@ target_link_libraries(i3ipc++
 )
 
 target_compile_options(i3ipc++
-	PRIVATE -std=c++11 -Wall -Wextra -Wno-unused-parameter
+	PRIVATE -std=c++17 -Wall -Wextra -Wno-unused-parameter
 )
 
 target_compile_definitions(i3ipc++

--- a/src/ipc-util.cpp
+++ b/src/ipc-util.cpp
@@ -8,6 +8,7 @@ extern "C" {
 #include <errno.h>
 }
 
+#include <algorithm>
 #include <cstring>
 #include <ios>
 
@@ -30,7 +31,7 @@ errno_error::errno_error(const std::string&  msg) : ipc_error(format_errno(msg))
 
 static const std::string  g_i3_ipc_magic = "i3-ipc";
 
-buf_t::buf_t(uint32_t  payload_size) : 
+buf_t::buf_t(uint32_t  payload_size) :
 	data(sizeof(header_t) + payload_size, 0),
 	header(reinterpret_cast<header_t*>(data.data())),
 	payload(reinterpret_cast<char*>(data.data() + sizeof(header_t)))
@@ -54,7 +55,7 @@ int32_t  i3_connect(const std::string&  socket_path) {
 	}
 
 	(void)fcntl(sockfd, F_SETFD, FD_CLOEXEC); // What for?
-	
+
 	struct sockaddr_un addr;
 	memset(&addr, 0, sizeof(struct sockaddr_un));
 	addr.sun_family = AF_LOCAL;


### PR DESCRIPTION
1. `std::copy_n` requires to `#include <algorithm>`
2. `std::optional` requires C++17 or newer

<details>
<summary>`make` output before any changes</summary>
<pre>
[ 33%] Building CXX object CMakeFiles/i3ipc++.dir/src/ipc-util.cpp.o
/home/zebradil/development/vendor/i3ipcpp/src/ipc-util.cpp: In constructor ‘i3ipc::buf_t::buf_t(uint32_t)’:
/home/zebradil/development/vendor/i3ipcpp/src/ipc-util.cpp:38:14: error: ‘copy_n’ is not a member of ‘std’; did you mean ‘copy’?
   38 |         std::copy_n(std::begin(g_i3_ipc_magic), sizeof(header->magic), header->magic);
      |              ^~~~~~
      |              copy
/home/zebradil/development/vendor/i3ipcpp/src/ipc-util.cpp: In function ‘std::shared_ptr<i3ipc::buf_t> i3ipc::i3_pack(ClientMessageType, const std::string&)’:
/home/zebradil/development/vendor/i3ipcpp/src/ipc-util.cpp:78:14: error: ‘copy_n’ is not a member of ‘std’; did you mean ‘copy’?
   78 |         std::copy_n(std::begin(payload), buff->header->size, buff->payload);
      |              ^~~~~~
      |              copy
make[2]: *** [CMakeFiles/i3ipc++.dir/build.make:76: CMakeFiles/i3ipc++.dir/src/ipc-util.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:83: CMakeFiles/i3ipc++.dir/all] Error 2
make: *** [Makefile:91: all] Error 2

</pre>
</details>

<details>
<summary>`make` output after fixing `copy_n`</summary>

<pre>
Consolidate compiler generated dependencies of target i3ipc++
[ 33%] Building CXX object CMakeFiles/i3ipc++.dir/src/ipc-util.cpp.o
[ 66%] Building CXX object CMakeFiles/i3ipc++.dir/src/ipc.cpp.o
In file included from /home/zebradil/development/vendor/i3ipcpp/src/ipc.cpp:12:
/home/zebradil/development/vendor/i3ipcpp/include/i3ipc++/ipc.hpp:202:14: error: ‘optional’ in namespace ‘std’ does not name a template type
  202 |         std::optional<std::string> workspace;
      |              ^~~~~~~~
/home/zebradil/development/vendor/i3ipcpp/include/i3ipc++/ipc.hpp:202:9: note: ‘std::optional’ is only available from C++17 onwards
  202 |         std::optional<std::string> workspace;
      |         ^~~
/home/zebradil/development/vendor/i3ipcpp/src/ipc.cpp:79:92: error: ‘std::optional’ has not been declared
   79 | static std::shared_ptr<container_t>  parse_container_from_json(const Json::Value&  o, std::optional<std::string> workspace_name = std::nullopt) {
      |                                                                                            ^~~~~~~~
/home/zebradil/development/vendor/i3ipcpp/src/ipc.cpp:79:100: error: expected ‘,’ or ‘...’ before ‘<’ token
   79 | static std::shared_ptr<container_t>  parse_container_from_json(const Json::Value&  o, std::optional<std::string> workspace_name = std::nullopt) {
      |                                                                                                    ^
/home/zebradil/development/vendor/i3ipcpp/src/ipc.cpp: In function ‘std::shared_ptr<i3ipc::container_t> i3ipc::parse_container_from_json(const Json::Value&, int)’:
/home/zebradil/development/vendor/i3ipcpp/src/ipc.cpp:146:13: warning: init-statement in selection statements only available with ‘-std=c++17’ or ‘-std=gnu++17’ [-Wc++17-extensions]
  146 |         if (Json::Value value{o["name"]}; container->type == "workspace" && !value.isNull()) {
      |             ^~~~
/home/zebradil/development/vendor/i3ipcpp/src/ipc.cpp:147:28: error: ‘using element_type = struct i3ipc::container_t’ {aka ‘struct i3ipc::container_t’} has no member named ‘workspace’
  147 |                 container->workspace = value.asString();
      |                            ^~~~~~~~~
/home/zebradil/development/vendor/i3ipcpp/src/ipc.cpp:150:28: error: ‘using element_type = struct i3ipc::container_t’ {aka ‘struct i3ipc::container_t’} has no member named ‘workspace’
  150 |                 container->workspace = workspace_name;
      |                            ^~~~~~~~~
/home/zebradil/development/vendor/i3ipcpp/src/ipc.cpp:150:40: error: ‘workspace_name’ was not declared in this scope; did you mean ‘workspace_t’?
  150 |                 container->workspace = workspace_name;
      |                                        ^~~~~~~~~~~~~~
      |                                        workspace_t
/home/zebradil/development/vendor/i3ipcpp/src/ipc.cpp:158:99: error: ‘using element_type = struct i3ipc::container_t’ {aka ‘struct i3ipc::container_t’} has no member named ‘workspace’
  158 |                         container->nodes.push_back(parse_container_from_json(nodes[i], container->workspace));
      |                                                                                                   ^~~~~~~~~
/home/zebradil/development/vendor/i3ipcpp/src/ipc.cpp:166:117: error: ‘using element_type = struct i3ipc::container_t’ {aka ‘struct i3ipc::container_t’} has no member named ‘workspace’
  166 |                         container->floating_nodes.push_back(parse_container_from_json(floating_nodes[i], container->workspace));
      |                                                                                                                     ^~~~~~~~~
/home/zebradil/development/vendor/i3ipcpp/src/ipc.cpp: In lambda function:
/home/zebradil/development/vendor/i3ipcpp/src/ipc.cpp:415:73: error: too few arguments to function ‘std::shared_ptr<i3ipc::container_t> i3ipc::parse_container_from_json(const Json::Value&, int)’
  415 |                                 ev.container = parse_container_from_json(container);
      |                                                ~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~
/home/zebradil/development/vendor/i3ipcpp/src/ipc.cpp:79:38: note: declared here
   79 | static std::shared_ptr<container_t>  parse_container_from_json(const Json::Value&  o, std::optional<std::string> workspace_name = std::nullopt) {
      |                                      ^~~~~~~~~~~~~~~~~~~~~~~~~
/home/zebradil/development/vendor/i3ipcpp/src/ipc.cpp: In member function ‘std::shared_ptr<i3ipc::container_t> i3ipc::connection::get_tree() const’:
/home/zebradil/development/vendor/i3ipcpp/src/ipc.cpp:564:41: error: too few arguments to function ‘std::shared_ptr<i3ipc::container_t> i3ipc::parse_container_from_json(const Json::Value&, int)’
  564 |         return parse_container_from_json(root);
      |                ~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~
/home/zebradil/development/vendor/i3ipcpp/src/ipc.cpp:79:38: note: declared here
   79 | static std::shared_ptr<container_t>  parse_container_from_json(const Json::Value&  o, std::optional<std::string> workspace_name = std::nullopt) {
      |                                      ^~~~~~~~~~~~~~~~~~~~~~~~~
make[2]: *** [CMakeFiles/i3ipc++.dir/build.make:90: CMakeFiles/i3ipc++.dir/src/ipc.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:83: CMakeFiles/i3ipc++.dir/all] Error 2
make: *** [Makefile:91: all] Error 2

</pre>

</details>