### PR TITLE
Fix assertion fail when using a non i3 window manager

### DIFF
--- a/src/ipc.cpp
+++ b/src/ipc.cpp
@@ -325,7 +325,7 @@ std::string  get_socketpath() {
 		pclose(in);
 		str = str_buf;
 	}
-	if (str.back() == '\n') {
+	if (str.length() > 0 && str.back() == '\n') {
 		str.pop_back();
 	}
 	return str;


### PR DESCRIPTION
Hello

I stumbled upon a problem with my KDE Plasma/I3 setup, where a plasmoid that uses i3ipcpp crashes the login procedure  when trying to log into the native X11 version of Plasma. The root of this problem was a failed assertion. I3ipcpp tried to run `back()` on a string that became empty, as the window manager was wrong and `i3 --get-socketpath` therefore returned an empty string.

Here is a fix for that, which wont effect any application running using i3. I hope that you're interested in accepting it.