### PR TITLE
Optionally support sig-c++-3.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,8 @@
-build
-doc
+build/
+doc/
 *.sublime-workspace
 *.log
+
+.ccls*
+*.o
+compile_commands.*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,10 +4,20 @@ project(i3ipc++)
 option(I3IPCpp_WITH_TESTS "Build unit tests executables" OFF)
 option(I3IPCpp_BUILD_EXAMPLES "Build example executables" OFF)
 
-find_package(PkgConfig)
-pkg_check_modules(SIGCPP REQUIRED sigc++-2.0)
-pkg_check_modules(JSONCPP REQUIRED jsoncpp)
 
+file(GLOB_RECURSE SRC src/*.cpp)
+add_library(i3ipc++ ${SRC})
+
+find_package(PkgConfig)
+pkg_check_modules(JSONCPP REQUIRED jsoncpp)
+pkg_check_modules(SIGCPP  sigc++-3.0)
+if(SIGCPP_FOUND)
+   target_compile_definitions(i3ipc++
+ 	PUBLIC I3CPP_IPC_SIGCPP3=${SIGCPP_FOUND}
+  )
+else()
+pkg_check_modules(SIGCPP REQUIRED sigc++-2.0)
+endif()
 
 set(I3IPCpp_INCLUDE_DIRS
 	${SIGCPP_INCLUDE_DIRS}
@@ -31,8 +41,6 @@ set(I3IPCpp_LIBRARIES
 # set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -g3 -DDEBUG")
 # set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O2")
 
-file(GLOB_RECURSE SRC src/*.cpp)
-add_library(i3ipc++ ${SRC})
 
 target_include_directories(i3ipc++
 	PUBLIC

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,6 @@
 cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 project(i3ipc++)
 
-string(TIMESTAMP I3IPCppBUILD_DATETIME "%Y-%m-%d %H:%M:%S")
-
 option(I3IPCpp_WITH_TESTS "Build unit tests executables" OFF)
 option(I3IPCpp_BUILD_EXAMPLES "Build example executables" OFF)
 
@@ -58,10 +56,6 @@ target_link_libraries(i3ipc++
 
 target_compile_options(i3ipc++
 	PRIVATE -std=c++17 -Wall -Wextra -Wno-unused-parameter
-)
-
-target_compile_definitions(i3ipc++
-	PRIVATE I3IPC_BUILD_DATETIME="${I3IPCppBUILD_DATETIME}"
 )
 
 if (CMAKE_BUILD_TYPE STREQUAL "DEBUG")

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ An implementation of i3 IPC in C++11.
 * C++11 compiler
 * sigc++ 2.0
 * jsoncpp
+* i3 (for i3/ipc.h)
 
 ## Using
 Yet the only way of using is to add this repo as a submodule

--- a/include/i3ipc++/ipc.hpp
+++ b/include/i3ipc++/ipc.hpp
@@ -369,14 +369,21 @@ public:
 	 * Disconnect the event socket
 	 */
 	void  disconnect_event_socket();
-
-	sigc::signal<void, const workspace_event_t&>  signal_workspace_event; ///< Workspace event signal
+#ifdef I3CPP_IPC_SIGCPP3
+        sigc::signal<void(const workspace_event_t&)>  signal_workspace_event; ///< Workspace event signal
+	sigc::signal<void()> signal_output_event; ///< Output event signal
+	sigc::signal<void(const mode_t&)>  signal_mode_event; ///< Output mode event signal
+	sigc::signal<void(const window_event_t&)>  signal_window_event; ///< Window event signal
+	sigc::signal<void(const bar_config_t&)>  signal_barconfig_update_event; ///< Barconfig update event signal
+	sigc::signal<void(const binding_t&)>  signal_binding_event; ///< Binding event signal
+	sigc::signal<void(EventType, const std::shared_ptr<const buf_t>&)>  signal_event; ///< i3 event signal @note Default handler routes event to signal according to type
+#else
+    sigc::signal<void, const workspace_event_t&>  signal_workspace_event; ///< Workspace event signal
 	sigc::signal<void>  signal_output_event; ///< Output event signal
 	sigc::signal<void, const mode_t&>  signal_mode_event; ///< Output mode event signal
 	sigc::signal<void, const window_event_t&>  signal_window_event; ///< Window event signal
 	sigc::signal<void, const bar_config_t&>  signal_barconfig_update_event; ///< Barconfig update event signal
-	sigc::signal<void, const binding_t&>  signal_binding_event; ///< Binding event signal
-	sigc::signal<void, EventType, const std::shared_ptr<const buf_t>&>  signal_event; ///< i3 event signal @note Default handler routes event to signal according to type
+#endif
 private:
 	const int32_t  m_main_socket;
 	int32_t  m_event_socket;

--- a/src/ipc.cpp
+++ b/src/ipc.cpp
@@ -661,7 +661,7 @@ const version_t&  get_version() {
 #define I3IPC_VERSION_MINOR  5
 #define I3IPC_VERSION_PATCH  0
 	static version_t  version = {
-		.human_readable = auss_t() << I3IPC_VERSION_MAJOR << '.' << I3IPC_VERSION_MINOR << '.' << I3IPC_VERSION_PATCH  << " (built on " << I3IPC_BUILD_DATETIME << ")",
+		.human_readable = auss_t() << I3IPC_VERSION_MAJOR << '.' << I3IPC_VERSION_MINOR << '.' << I3IPC_VERSION_PATCH,
 		.loaded_config_file_name = std::string(),
 		.major = I3IPC_VERSION_MAJOR,
 		.minor = I3IPC_VERSION_MINOR,

--- a/test/test_ipc.hpp
+++ b/test/test_ipc.hpp
@@ -14,7 +14,7 @@ public:
 			auto  buff = i3_pack(ClientMessageType::COMMAND, "exit");
 			auss_t  auss;
 			auss << std::hex;
-			for (uint32_t  i = 0; i < buff->size; i++) {
+			for (uint32_t  i = 0; i < buff->data.size(); i++) {
 				if (buff->data[i] < 0x10) {
 					auss << '0';
 				}


### PR DESCRIPTION
Fall back to sig-c++2.0 if not found.
Contains #40.